### PR TITLE
Composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "sebastianbergmann/php-text-template",
+    "description": "Text_Template: Simple template engine",
+    "keywords": ["template"],
+    "homepage": "https://github.com/sebastianbergmann/php-text-template",
+    "license": "The BSD 3-Clause License",
+    "authors": [
+        {
+            "name": "Sebastian Bergmann",
+            "homepage": "http://sebastian-bergmann.de/"
+        }
+    ],
+    "autoload": {
+        "psr-0": { "Text": "" }
+    },
+    "require": {
+        "php": ">=5.2.7"
+    }
+}


### PR DESCRIPTION
Hi there. I need Text_Template as a requirement for a package and composer is failing to install it via pear claiming the version is not stable enough (even though package.xml says 1.1.1 is stable).

As it stands on my pull request the vendor/library is sebastianbergmann/php-text-template. I will create the vendor on packagist. I am happy to move it to you adding you as maintainer and removing my user from it whenever you want.

Until you merge this request, packagist will point to my github repo. I will immediately point it to yours as soon as you have this composer.json on your repo. Alternatively you can use the packagist token to allow it to update the package automatically for every release you make.

Let me know your thoughts. And thanks for Text_Template and all your open source contributions!
