### PR TITLE
Remove obsolete 'include-path' from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,5 @@
         "classmap": [
             "Text/"
         ]
-    },
-    "include-path": [
-        ""
-    ]
+    }
 }


### PR DESCRIPTION
There are no tests here yet - hence, no Travis integration.
