### PR TITLE
Update .gitattributes to export-ignore .psalm directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,9 +3,9 @@
 /.github        export-ignore
 /.phive         export-ignore
 /.php_cs.dist   export-ignore
+/.psalm         export-ignore
 /build.xml      export-ignore
 /phpunit.xml    export-ignore
-/psalm.xml      export-ignore
 /tests          export-ignore
 /tools          export-ignore
 /tools/*        binary


### PR DESCRIPTION
Similar to sebastianbergmann/php-timer#35, to exclude the new `.psalm` directory on git exports.

Thank you.